### PR TITLE
minimal change to use the permanent geocoding API

### DIFF
--- a/hud_api_replace/geocode.py
+++ b/hud_api_replace/geocode.py
@@ -1,18 +1,27 @@
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 
-import json
-import hmac
-import base64
-import hashlib
 import geocoder
-from geocoder.mapbox import Mapbox
+from geocoder.mapbox import Mapbox, mapbox_access_token
 
 import re
 import time
 
 from hud_api_replace.models import CachedGeodata
 
+
+class PermanentMapbox(Mapbox):
+    def __init__(self, location, **kwargs):
+        self.location = location
+        self.url = u'https://api.mapbox.com/geocoding/v5/mapbox.places-permanent/{0}.json'.format(location)
+        self.params = {
+            'access_token': self._get_api_key(mapbox_access_token, **kwargs),
+            'country': kwargs.get('country'),
+            'proximity': self._get_proximity(),
+            'types': kwargs.get('types'),
+        }
+        self._get_proximity(**kwargs)
+        self._initialize(**kwargs)
 
 
 def _extract_zip_code(key):
@@ -25,18 +34,19 @@ def _extract_zip_code(key):
 
 def geocode_get_data(address, zip_only=False):
     """Main function to obtain geocoding information."""
-    address = str(address) + ", usa"
     try:
         cached = CachedGeodata.objects.all().filter(expires__gte=time.time()).get(key=address)
     except ObjectDoesNotExist:
         if zip_only:
-            mb_result = Mapbox(address ,types='postcode')
+            mb_result = PermanentMapbox(address,
+                                        types='postcode',
+                                        country='us')
             if mb_result.latlng:
                 result = mb_result
             else:
                 result = geocoder.osm(address)
         else:
-            result = geocoder.mapbox(address)
+            result = PermanentMapbox(address, country="us")
         cached, created = CachedGeodata.objects.get_or_create(key=address)
         cached.lat = result.lat
         cached.lon = result.lng

--- a/hud_api_replace/geocode.py
+++ b/hud_api_replace/geocode.py
@@ -41,12 +41,9 @@ def geocode_get_data(address, zip_only=False):
             mb_result = PermanentMapbox(address,
                                         types='postcode',
                                         country='us')
-            if mb_result.latlng:
-                result = mb_result
-            else:
-                result = geocoder.osm(address)
+            result = mb_result
         else:
-            result = PermanentMapbox(address, country="us")
+            result = PermanentMapbox(address, country='us')
         cached, created = CachedGeodata.objects.get_or_create(key=address)
         cached.lat = result.lat
         cached.lon = result.lng

--- a/hud_api_replace/tests/test_geocode.py
+++ b/hud_api_replace/tests/test_geocode.py
@@ -28,10 +28,10 @@ class TestGeocode(TestCase):
 
     def test_geocode_get_data__existent(self):
         """Testing geocode_get_data, with cached argument."""
-        cg = CachedGeodata(key='20005, usa', lat=111, lon=222, expires=time.time() + 10000)
+        cg = CachedGeodata(key='20005', lat=111, lon=222, expires=time.time() + 10000)
         cg.save()
         result = geocode_get_data('20005')
         self.assertTrue('zip' in result)
-        self.assertEqual(result['zip']['zipcode'], '20005, usa')
+        self.assertEqual(result['zip']['zipcode'], '20005')
         self.assertEqual(result['zip']['lat'], 111)
         self.assertEqual(result['zip']['lng'], 222)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist=True
-envlist=py{27,35}-dj{18,110}
+envlist=py{27,35}-dj{18,111}
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}


### PR DESCRIPTION
I attempted to do something more extensive (see: https://github.com/cfpb/django-hud/compare/master...loader-refactor?expand=1 ), but every thread I followed led me to something else I wanted to fix, and it became unweildy.

So, this here is the minimal change needed to satisfy the request our vendor has made to use their permanent geocoder service. I'll open issues for the other landmines I've found.