### PR TITLE
Configure travis to build a wheel of the app, and attach it to the Github release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,25 @@
 language: python
 cache: pip
-
 matrix:
   include:
-    - env: TOXENV=py27-dj18
-      python: 2.7
-    - env: TOXENV=py27-dj110
-      python: 2.7
-    - env: TOXENV=py35-dj18
-      python: 3.5
-    - env: TOXENV=py35-dj110
-      python: 3.5
-
-install:
-  pip install tox coveralls
-
-script:
-  tox
-
-after_success:
-  coveralls
+  - env: TOXENV=py27-dj18
+    python: 2.7
+  - env: TOXENV=py27-dj110
+    python: 2.7
+  - env: TOXENV=py35-dj18
+    python: 3.5
+  - env: TOXENV=py35-dj110
+    python: 3.5
+install: pip install tox coveralls
+script: tox
+after_success: coveralls
+before_deploy: "pip wheel ."
+deploy:
+  provider: releases
+  api_key:
+    secure:
+      secure: W0U4AdpqLVjNXOygZ4ceM7f63Jw0o2QM5Hwpu3hC25JybMgE5ZFohk5STqhRP5/BnQxz0UnQCzjnLX4rzPILYmVJ1AjiYrUWkh/HluMGXicTBkDc1LF3pV70offkeMxfnDOZg7BmRdBGETgnOUZbGqi++iYKWc6alqhoTvizp18=
+  file: '*.whl'
+  skip_cleanup: true
+  on:
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 language: python
 cache: pip
-matrix:
+install: pip install tox coveralls
+script: tox
+python: 2.7
+jobs:
   include:
-  - env: TOXENV=py27-dj18
+  - stage: tests
+    env: TOXENV=py27-dj18
     python: 2.7
   - env: TOXENV=py27-dj110
     python: 2.7
@@ -10,16 +14,14 @@ matrix:
     python: 3.5
   - env: TOXENV=py35-dj110
     python: 3.5
-install: pip install tox coveralls
-script: tox
-after_success: coveralls
-before_deploy: "pip wheel ."
-deploy:
-  provider: releases
-  api_key:
-    secure:
-      secure: W0U4AdpqLVjNXOygZ4ceM7f63Jw0o2QM5Hwpu3hC25JybMgE5ZFohk5STqhRP5/BnQxz0UnQCzjnLX4rzPILYmVJ1AjiYrUWkh/HluMGXicTBkDc1LF3pV70offkeMxfnDOZg7BmRdBGETgnOUZbGqi++iYKWc6alqhoTvizp18=
-  file: '*.whl'
-  skip_cleanup: true
-  on:
-    tags: true
+  - stage: GitHub Release
+    script: python2.7 setup.py bdist_wheel
+    deploy:
+      provider: releases
+      skip_cleanup: true
+      api_key:
+        secure: MJCHgq7IYckdvuCE1eRkm75UGmQGOI0UoYfFkC8VGZOUjs0HBxJfrppzBH/KPzjbhRcfzJfhClvYYcRin3DBKNbSy8sHWil86dcfrGOidStv68Fu/Pa2ZDYA4TVaDS+x1s8/SRqyKcLBqHZeVUBTrzQ0UxxEadeaYQ/F10BcZJg=
+      file_glob: true
+      file: dist/*.whl
+      on:
+        tags: true


### PR DESCRIPTION
The flow will be:
- developer or releaser creates a new "[release](https://github.com/cfpb/django-hud/releases)" of this app
- Travis will run it's usual tests
- Travis then generate a distributable package of the app ("wheel") and attach it to the Github release object. The end result will look like this: https://github.com/rosskarchner/django-hud/releases/tag/9.0.0

Interesting points and compromises:
- In order to make the deployment happen after all of the test jobs pass, it made sense to use [build stages](https://docs.travis-ci.com/user/build-stages/), which are a "beta" feature of travis.
- There seems to be a conflict between the "matrix" directive and build stages. Thankfully, we aren't *actually* creating a matrix of tests, and those jobs could be moved from matrix.include to jobs.include.
- The Travis status on this PR won't tell us anything useful, because this functionality only comes into play when a new tag is created. Here's what it looks like in Travis, when it's working: https://travis-ci.org/rosskarchner/django-hud/builds/253735533