### PR TITLE
Add additional index to CachedGeoData

### DIFF
--- a/hud_api_replace/migrations/0002_add_index_together.py
+++ b/hud_api_replace/migrations/0002_add_index_together.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('hud_api_replace', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterIndexTogether(
+            name='cachedgeodata',
+            index_together=set([('key', 'expires')]),
+        ),
+    ]

--- a/hud_api_replace/models.py
+++ b/hud_api_replace/models.py
@@ -1,8 +1,6 @@
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
 
-import datetime
-
 
 class CachedGeodata(models.Model):
     """Model to save geocoding information locally."""
@@ -10,6 +8,11 @@ class CachedGeodata(models.Model):
     lat = models.FloatField('Latitude', null=True)
     lon = models.FloatField('Longitude', null=True)
     expires = models.PositiveIntegerField(null=True)
+
+    class Meta:
+        index_together = (
+            ('key', 'expires'),
+        )
 
 
 @python_2_unicode_compatible


### PR DESCRIPTION
@marcesher made the observation that queries against cached geodata
could potentially be optimized through use of an additional index. When
the cached geodata is queried in `hud_api_replace.geocode`, it's looked
up using Python code like

```py
CachedGeodata.objects.filter(expires__gte=time.time()).get(key=address)
```

In practice this results in SQL like

```sql
SELECT * FROM hud_api_replace_cachedgeodata
WHERE expires >= %s AND key = %s
```

This commit adds a joint index on these two columns, which should speed
up these queries. See Django documentation on `index_together` at

https://docs.djangoproject.com/en/1.8/ref/models/options/#index-together